### PR TITLE
fix compile with c++ >=17

### DIFF
--- a/cores/snes/conffile.cpp
+++ b/cores/snes/conffile.cpp
@@ -632,7 +632,7 @@ void ConfigFile::ClearLines()
     }
 }
 
-bool ConfigFile::ConfigEntry::section_then_key_less::operator()(const ConfigEntry &a, const ConfigEntry &b) {
+bool ConfigFile::ConfigEntry::section_then_key_less::operator()(const ConfigEntry &a, const ConfigEntry &b) const {
 	if(curConfigFile && a.section!=b.section){
 		const int sva = curConfigFile->GetSectionSize(a.section);
 		const int svb = curConfigFile->GetSectionSize(b.section);

--- a/cores/snes/conffile.h
+++ b/cores/snes/conffile.h
@@ -267,18 +267,18 @@ class ConfigFile {
 		mutable bool used;
 
         struct section_then_key_less {
-            bool operator()(const ConfigEntry &a, const ConfigEntry &b);
+            bool operator()(const ConfigEntry &a, const ConfigEntry &b) const;
         };
 
         struct key_less {
-            bool operator()(const ConfigEntry &a, const ConfigEntry &b) const{
+            bool operator()(const ConfigEntry &a, const ConfigEntry &b) const {
                 if(a.section!=b.section) return a.section<b.section;
                 return a.key<b.key;
             }
         };
 
         struct line_less {
-            bool operator()(const ConfigEntry &a, const ConfigEntry &b){
+            bool operator()(const ConfigEntry &a, const ConfigEntry &b) const {
 				if(a.line==b.line) return (b.val.empty() && !a.val.empty()) || a.key<b.key;
                 if(b.line<0) return true;
                 if(a.line<0) return false;


### PR DESCRIPTION
Newer versions of the C++ standard require that operator() methods used by std::set are explicitly marked as const. Without this patch compiling fails with an error like:
`Error: static assertion failed: comparison object must be invocable as const`