### PR TITLE
Add flake8 to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,17 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: detect-private-key
       - id: debug-statements
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args:
+          - '--per-file-ignores=*/__init__.py:F401'
+          - --ignore=E203,W503,E741
+          - --max-complexity=50
+          - --max-line-length=456
+          - --show-source
+          - --statistics
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1
     hooks:

--- a/cores/gba/src/platform/python/conftest.py
+++ b/cores/gba/src/platform/python/conftest.py
@@ -3,7 +3,6 @@ import itertools
 import os
 import os.path
 
-import pytest
 import yaml
 
 

--- a/cores/gba/src/platform/python/mgba/core.py
+++ b/cores/gba/src/platform/python/mgba/core.py
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from cached_property import cached_property
 
-from . import createCallback, tile
+from . import tile
 from ._pylib import ffi, lib
 
 

--- a/cores/gba/src/platform/python/mgba/debugger.py
+++ b/cores/gba/src/platform/python/mgba/debugger.py
@@ -3,7 +3,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import io
 import sys
 
 from ._pylib import ffi, lib

--- a/cores/gba/src/platform/python/mgba/lr35902.py
+++ b/cores/gba/src/platform/python/mgba/lr35902.py
@@ -39,7 +39,7 @@ class LR35902Core:
         return self._native.h
 
     @property
-    def l(self):
+    def l(self):  # noqa: 743
         return self._native.l
 
     @property
@@ -96,7 +96,7 @@ class LR35902Core:
         self._native.h = value
 
     @l.setter
-    def l(self, value):
+    def l(self, value):  # noqa: 743
         self._native.l = value
 
     @sp.setter

--- a/cores/gba/src/platform/python/mgba/vfs.py
+++ b/cores/gba/src/platform/python/mgba/vfs.py
@@ -3,7 +3,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import mmap
 import os
 
 from ._pylib import ffi, lib

--- a/cores/gba/src/platform/python/tests/mgba/test_core.py
+++ b/cores/gba/src/platform/python/tests/mgba/test_core.py
@@ -1,8 +1,5 @@
-import pytest
-
-
 def test_core_import():
     try:
-        import mgba.core
-    except:
+        import mgba.core  # noqa: F401
+    except Exception:
         raise AssertionError

--- a/cores/gba/src/platform/python/tests/mgba/test_vfs.py
+++ b/cores/gba/src/platform/python/tests/mgba/test_vfs.py
@@ -1,7 +1,6 @@
 import os
 
 import mgba.vfs as vfs
-import pytest
 from mgba._pylib import ffi
 
 

--- a/cores/gba/tools/deploy-mac.py
+++ b/cores/gba/tools/deploy-mac.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import subprocess
+from functools import reduce
 
 qtPath = None
 verbose = False

--- a/cores/gba/tools/perf.py
+++ b/cores/gba/tools/perf.py
@@ -41,7 +41,7 @@ class PerfTest:
         try:
             self.wait(proc)
             proc.wait()
-        except:
+        except Exception:
             proc.kill()
             raise
         if proc.returncode:
@@ -155,7 +155,6 @@ class Suite:
 
     def run(self):
         results = []
-        sock = None
         for test in self.tests:
             print(f"Running test {test.name}", file=sys.stderr)
             if self.server:

--- a/retro/cores/gba/src/platform/python/conftest.py
+++ b/retro/cores/gba/src/platform/python/conftest.py
@@ -3,7 +3,6 @@ import itertools
 import os
 import os.path
 
-import pytest
 import yaml
 
 

--- a/retro/cores/gba/src/platform/python/mgba/debugger.py
+++ b/retro/cores/gba/src/platform/python/mgba/debugger.py
@@ -3,7 +3,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import io
 import sys
 
 from ._pylib import ffi, lib

--- a/retro/cores/gba/src/platform/python/mgba/lr35902.py
+++ b/retro/cores/gba/src/platform/python/mgba/lr35902.py
@@ -39,7 +39,7 @@ class LR35902Core:
         return self._native.h
 
     @property
-    def l(self):
+    def l(self):  # noqa: 743
         return self._native.l
 
     @property
@@ -96,7 +96,7 @@ class LR35902Core:
         self._native.h = value
 
     @l.setter
-    def l(self, value):
+    def l(self, value):  # noqa: 743
         self._native.l = value
 
     @sp.setter

--- a/retro/cores/gba/src/platform/python/mgba/vfs.py
+++ b/retro/cores/gba/src/platform/python/mgba/vfs.py
@@ -3,7 +3,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import mmap
 import os
 
 from ._pylib import ffi, lib

--- a/retro/cores/gba/src/platform/python/tests/mgba/test_core.py
+++ b/retro/cores/gba/src/platform/python/tests/mgba/test_core.py
@@ -1,8 +1,5 @@
-import pytest
-
-
 def test_core_import():
     try:
-        import mgba.core
-    except:
+        import mgba.core  # noqa: F401
+    except Exception:
         raise AssertionError

--- a/retro/cores/gba/src/platform/python/tests/mgba/test_vfs.py
+++ b/retro/cores/gba/src/platform/python/tests/mgba/test_vfs.py
@@ -1,7 +1,6 @@
 import os
 
 import mgba.vfs as vfs
-import pytest
 from mgba._pylib import ffi
 
 

--- a/retro/cores/gba/tools/deploy-mac.py
+++ b/retro/cores/gba/tools/deploy-mac.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import subprocess
+from functools import reduce
 
 qtPath = None
 verbose = False

--- a/retro/cores/gba/tools/perf.py
+++ b/retro/cores/gba/tools/perf.py
@@ -41,9 +41,9 @@ class PerfTest:
         try:
             self.wait(proc)
             proc.wait()
-        except:
+        except Exception as e:
             proc.kill()
-            raise
+            raise e
         if proc.returncode:
             print("Game crashed!", file=sys.stderr)
             return
@@ -155,7 +155,6 @@ class Suite:
 
     def run(self):
         results = []
-        sock = None
         for test in self.tests:
             print(f"Running test {test.name}", file=sys.stderr)
             if self.server:

--- a/retro/examples/trivial_random_agent.py
+++ b/retro/examples/trivial_random_agent.py
@@ -3,12 +3,12 @@ import retro
 
 def main():
     env = retro.make(game="Airstriker-Genesis")
-    obs = env.reset()
+    env.reset()
     while True:
         obs, rew, done, info = env.step(env.action_space.sample())
         env.render()
         if done:
-            obs = env.reset()
+            env.reset()
     env.close()
 
 

--- a/retro/examples/trivial_random_agent_multiplayer.py
+++ b/retro/examples/trivial_random_agent_multiplayer.py
@@ -3,7 +3,7 @@ import retro
 
 def main():
     env = retro.make(game="Pong-Atari2600", players=2)
-    obs = env.reset()
+    env.reset()
     while True:
         # action_space will by MultiBinary(16) now instead of MultiBinary(8)
         # the bottom half of the actions will be for player 1 and the top half for player 2
@@ -12,7 +12,7 @@ def main():
         # done and info will remain the same
         env.render()
         if done:
-            obs = env.reset()
+            env.reset()
     env.close()
 
 

--- a/retro/rendering.py
+++ b/retro/rendering.py
@@ -10,10 +10,10 @@ except ImportError as e:
     But if you really just want to install all Gym dependencies and not have to think about it,
     'pip install -e .[all]' or 'pip install gym[all]' will do it.
     """
-    )
+    ) from e
 
 try:
-    from pyglet.gl import *
+    from pyglet.gl import gl
 except ImportError as e:
     raise ImportError(
         """
@@ -22,7 +22,7 @@ except ImportError as e:
     If you're running on a server, you may need a virtual frame buffer; something like this should work:
     'xvfb-run -s \"-screen 0 1400x900x24\" python <your_script.py>'
     """
-    )
+    ) from e
 
 
 def get_window(width, height, display, **kwargs):

--- a/retro/testing/tools.py
+++ b/retro/testing/tools.py
@@ -1,5 +1,3 @@
-import glob
-import hashlib
 import json
 import os
 import re
@@ -13,8 +11,8 @@ def load_whitelist(game, inttype):
             retro.data.get_file_path(
                 game, "metadata.json", inttype | retro.data.Integrations.STABLE
             )
-        ) as f:
-            whitelist = json.load(f).get("whitelist", {})
+        ) as metadata_file:
+            whitelist = json.load(metadata_file).get("whitelist", {})
     except json.JSONDecodeError:
         return None, [(metadata_file, "fail decode")]
     except OSError:
@@ -326,7 +324,7 @@ def verify_extension(game, inttype):
 
 def verify_rom(game, inttype):
     try:
-        rom = retro.data.get_romfile_path(game, inttype=inttype)
+        retro.data.get_romfile_path(game, inttype=inttype)
     except FileNotFoundError:
         return [], [(game, "ROM file missing")]
 

--- a/retro/testing/verify_changes.py
+++ b/retro/testing/verify_changes.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import subprocess
 import sys
 
 import pytest

--- a/tests/data/test_integration.py
+++ b/tests/data/test_integration.py
@@ -1,5 +1,5 @@
 import retro.testing.tools
-from retro.testing import game, handle
+from retro.testing import handle
 
 
 def test_data(game):

--- a/tests/data/test_load.py
+++ b/tests/data/test_load.py
@@ -1,6 +1,5 @@
 import gc
 import gzip
-import os
 import zlib
 from concurrent.futures import ProcessPoolExecutor, TimeoutError
 from concurrent.futures.process import BrokenProcessPool
@@ -8,7 +7,7 @@ from concurrent.futures.process import BrokenProcessPool
 import pytest
 
 import retro
-from retro.testing import game, handle
+from retro.testing import handle
 
 pool = ProcessPoolExecutor(1)
 

--- a/tests/data/test_roms.py
+++ b/tests/data/test_roms.py
@@ -1,6 +1,6 @@
 import retro.data
 import retro.testing.tools
-from retro.testing import game, handle
+from retro.testing import handle
 
 
 def test_hash(game):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 import retro
-from retro.testing import handle, testenv
 
 
 def test_env_create(testenv):
@@ -13,9 +12,6 @@ def test_env_create(testenv):
 
 @pytest.mark.parametrize("obs_type", [retro.Observations.IMAGE, retro.Observations.RAM])
 def test_env_basic(obs_type, testenv):
-    import gymnasium as gym
-    import numpy as np
-
     json_path = os.path.join(os.path.dirname(__file__), "dummy.json")
     env = testenv(info=json_path, scenario=json_path, obs_type=obs_type)
     obs, _info = env.reset()


### PR DESCRIPTION
As flake8 requires hand-changing all of the code, I would prefer we not merge this until we have proper testing to check that this all works still.
I have decided not to fix the following errors as I think these are actual issues we need to find
```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

cores/gba/src/platform/python/cinema/movie.py:50:16: F821 undefined name 'mCoreOutput'
        return mCoreOutput(video=self.video(generator=generator, **kwargs))
               ^
cores/gba/src/platform/python/mgba/image.py:7:1: F401 '._pylib.lib' imported but unused
from ._pylib import ffi, lib
^
cores/gba/src/platform/python/mgba/lr35902.py:6:1: F401 '._pylib.lib' imported but unused
from ._pylib import ffi, lib
^
retro/cores/gba/src/platform/python/cinema/movie.py:50:16: F821 undefined name 'mCoreOutput'
        return mCoreOutput(video=self.video(generator=generator, **kwargs))
               ^
retro/cores/gba/src/platform/python/mgba/core.py:8:1: F401 '.createCallback' imported but unused
from . import createCallback, tile
^
retro/cores/gba/src/platform/python/mgba/image.py:7:1: F401 '._pylib.lib' imported but unused
from ._pylib import ffi, lib
^
retro/cores/gba/src/platform/python/mgba/lr35902.py:6:1: F401 '._pylib.lib' imported but unused
from ._pylib import ffi, lib
^
retro/examples/determinism.py:200:23: F821 undefined name 'RetroState'
                env = RetroState(env)
                      ^
5     F401 '._pylib.lib' imported but unused
3     F821 undefined name 'mCoreOutput'
```